### PR TITLE
Rename Hestia system namespace to Tulio

### DIFF
--- a/bin/v-quick-install-app
+++ b/bin/v-quick-install-app
@@ -55,7 +55,7 @@ $application -> register('install')
 			$o  = explode('=', $option);
 			$data['webapp_'.$o[0]] = $o[1];
 		}
-		$hestia = new \Hestia\System\HestiaApp();
+                $hestia = new \Tulio\System\TulioApp();
 		if(class_exists("\Hestia\WebApp\Installers\\" . $app . "\\" . $app . "Setup") === false){
 			$output -> writeln('App not found');
 			return Command::FAILURE;
@@ -110,7 +110,7 @@ $application -> register('apps')
 	$output -> writeln('---------------------------------');
 	foreach($appInstallers as $appInstaller){
 		$app = basename(dirname($appInstaller));
-		$hestia = new \Hestia\System\HestiaApp();
+                $hestia = new \Tulio\System\TulioApp();
 		$domain = 'demo.tuliocp.com';
 		if( !file_exists(__DIR__ . "/../web/src/app/WebApp/Installers/" . $app . "/". $app . "Setup.php") ){
 			continue;
@@ -136,7 +136,7 @@ $application -> register('options')
 		$_SESSION['user'] = $user;
 		$v_domain = $input -> getArgument('domain');
 		$app = $input -> getArgument('app');
-		$hestia = new \Hestia\System\HestiaApp();
+                $hestia = new \Tulio\System\TulioApp();
 
 		if(class_exists("\Hestia\WebApp\Installers\\" . $app . "\\" . $app . "Setup") === false){
 			$output -> writeln('App not found');

--- a/web/add/webapp/index.php
+++ b/web/add/webapp/index.php
@@ -38,7 +38,7 @@ unset($output);
 if (!empty($_GET["app"])) {
 	$app = basename($_GET["app"]);
 
-	$hestia = new \Hestia\System\HestiaApp();
+        $hestia = new \Tulio\System\TulioApp();
 	$app_installer_class = "\Hestia\WebApp\Installers\\" . $app . "\\" . $app . "Setup";
 	if (class_exists($app_installer_class)) {
 		try {
@@ -88,7 +88,7 @@ if (!empty($_POST["ok"]) && !empty($app)) {
 if (!empty($installer)) {
 	render_page($user, $TAB, "setup_webapp");
 } else {
-	$hestia = new \Hestia\System\HestiaApp();
+        $hestia = new \Tulio\System\TulioApp();
 	$appInstallers = glob(__DIR__ . "/../../src/app/WebApp/Installers/*/*.php");
 
 	$v_web_apps = [];

--- a/web/locale/tuliocp.pot
+++ b/web/locale/tuliocp.pot
@@ -5018,7 +5018,7 @@ msgstr ""
 msgid "BACKUP"
 msgstr ""
 
-#: ../../web/src/app/System/HestiaApp.php:218
+#: ../../web/src/app/System/TulioApp.php:218
 msgid "Unable to add database!"
 msgstr ""
 

--- a/web/src/app/System/HestiaCommandResult.php
+++ b/web/src/app/System/HestiaCommandResult.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Hestia\System;
+namespace Tulio\System;
 
 use function json_decode;
 

--- a/web/src/app/System/TulioApp.php
+++ b/web/src/app/System/TulioApp.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Hestia\System;
+namespace Tulio\System;
 
 use Exception;
 use RuntimeException;
@@ -25,7 +25,7 @@ use function unlink;
 use function var_dump;
 use const DIRECTORY_SEPARATOR;
 
-class HestiaApp
+class TulioApp
 {
     public function addDirectory(string $path): void
     {

--- a/web/src/app/System/Util.php
+++ b/web/src/app/System/Util.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Hestia\System;
+namespace Tulio\System;
 
 class Util
 {

--- a/web/src/app/System/WebDomain.php
+++ b/web/src/app/System/WebDomain.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Hestia\System;
+namespace Tulio\System;
 
 class WebDomain
 {

--- a/web/src/app/WebApp/AppWizard.php
+++ b/web/src/app/WebApp/AppWizard.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Hestia\WebApp;
 
-use Hestia\System\HestiaApp;
+use Tulio\System\TulioApp;
 use Hestia\WebApp\InstallationTarget\InstallationTarget;
 use Hestia\WebApp\InstallationTarget\TargetDatabase;
 use Hestia\WebApp\InstallationTarget\TargetDomain;
@@ -23,7 +23,7 @@ class AppWizard
     public function __construct(
         private readonly InstallerInterface $installer,
         private readonly string $domain,
-        private readonly HestiaApp $appcontext,
+        private readonly TulioApp $appcontext,
     ) {
         if (!$appcontext->userOwnsDomain($domain)) {
             throw new RuntimeException('User does not have access to domain [$domain]');

--- a/web/src/app/WebApp/BaseSetup.php
+++ b/web/src/app/WebApp/BaseSetup.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Hestia\WebApp;
 
-use Hestia\System\HestiaApp;
+use Tulio\System\TulioApp;
 use Hestia\WebApp\InstallationTarget\InstallationTarget;
 use Hestia\WebApp\InstallationTarget\TargetDatabase;
 use RuntimeException;
@@ -21,7 +21,7 @@ abstract class BaseSetup implements InstallerInterface
     protected array $info;
     protected array $config;
 
-    public function __construct(protected HestiaApp $appcontext)
+    public function __construct(protected TulioApp $appcontext)
     {
     }
 

--- a/web/src/app/WebApp/InstallationTarget/TargetDomain.php
+++ b/web/src/app/WebApp/InstallationTarget/TargetDomain.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Hestia\WebApp\InstallationTarget;
 
-use Hestia\System\Util;
+use Tulio\System\Util;
 
 class TargetDomain
 {

--- a/web/src/app/WebApp/Installers/Flarum/FlarumSetup.php
+++ b/web/src/app/WebApp/Installers/Flarum/FlarumSetup.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Hestia\WebApp\Installers\Flarum;
 
-use Hestia\System\Util;
+use Tulio\System\Util;
 use Hestia\WebApp\BaseSetup;
 use Hestia\WebApp\InstallationTarget\InstallationTarget;
 

--- a/web/src/app/WebApp/Installers/Joomla/JoomlaSetup.php
+++ b/web/src/app/WebApp/Installers/Joomla/JoomlaSetup.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Hestia\WebApp\Installers\Joomla;
 
-use Hestia\System\Util;
+use Tulio\System\Util;
 use Hestia\WebApp\BaseSetup;
 use Hestia\WebApp\InstallationTarget\InstallationTarget;
 

--- a/web/src/app/WebApp/Installers/WordPress/WordPressSetup.php
+++ b/web/src/app/WebApp/Installers/WordPress/WordPressSetup.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Hestia\WebApp\Installers\WordPress;
 
-use Hestia\System\Util;
+use Tulio\System\Util;
 use Hestia\WebApp\BaseSetup;
 use Hestia\WebApp\InstallationTarget\InstallationTarget;
 

--- a/web/src/composer.json
+++ b/web/src/composer.json
@@ -1,7 +1,8 @@
 {
     "autoload": {
         "psr-4": {
-            "Hestia\\": "app/"
+            "Hestia\\": "app/",
+            "Tulio\\System\\": "app/System/"
         }
     },
     "require": {


### PR DESCRIPTION
## Summary
- rename the core system helper class to `TulioApp`
- update CLI and web installers to instantiate the renamed helper
- refresh translation metadata to point at the new file path
- retarget the `\Hestia\System\` namespace to `\Tulio\System\` and update autoload/use sites accordingly

## Testing
- composer dump-autoload

------
https://chatgpt.com/codex/tasks/task_b_68cef6d07608832283b8c4326958c41f