### PR TITLE
Fix installer legacy variable compatibility

### DIFF
--- a/func/main.sh
+++ b/func/main.sh
@@ -54,6 +54,12 @@ SENDMAIL="$TULIO/web/inc/mail-wrapper.php"
 TULIO_GIT_REPO="https://raw.githubusercontent.com/contaura/tuliocp"
 TULIO_THEMES="$TULIO/web/css/themes"
 TULIO_THEMES_CUSTOM="$TULIO/web/css/themes/custom"
+# Provide legacy Hestia variables for backwards compatibility
+: "${HESTIA_INSTALL_DIR:=$TULIO_INSTALL_DIR}"
+: "${HESTIA_COMMON_DIR:=$TULIO_COMMON_DIR}"
+: "${HESTIA_PHP:=$TULIO_PHP}"
+: "${HESTIA_THEMES:=$TULIO_THEMES}"
+: "${HESTIA_THEMES_CUSTOM:=$TULIO_THEMES_CUSTOM}"
 SCRIPT="$(basename $0)"
 CHECK_RESULT_CALLBACK=""
 

--- a/install/hst-install-debian.sh
+++ b/install/hst-install-debian.sh
@@ -30,6 +30,8 @@ codename="$(cat /etc/os-release | grep VERSION= | cut -f 2 -d \( | cut -f 1 -d \
 architecture="$(arch)"
 HESTIA_INSTALL_DIR="$HESTIA_ROOT/install/deb"
 HESTIA_COMMON_DIR="$HESTIA_ROOT/install/common"
+TULIO_INSTALL_DIR="$HESTIA_INSTALL_DIR"
+TULIO_COMMON_DIR="$HESTIA_COMMON_DIR"
 VERBOSE='no'
 
 # Define software versions


### PR DESCRIPTION
## Summary
- restore legacy Hestia environment variables in the shared function library so helper scripts can locate Tulio assets
- initialize Tulio installer directory variables in the Debian installer script for consistent path handling

## Testing
- `bash -n func/main.sh install/hst-install-debian.sh`


------
https://chatgpt.com/codex/tasks/task_b_68cf354700d883229fbd764899ab5b22