### PR TITLE
Improve PHP binary fallback for installers

### DIFF
--- a/bin/v-add-sys-dependencies
+++ b/bin/v-add-sys-dependencies
@@ -63,16 +63,36 @@ check_tulio_demo_mode
 #                       Action                             #
 #----------------------------------------------------------#
 
+system_php=$(command -v php 2>/dev/null || true)
+if [ -z "$system_php" ] && [ -x "/usr/bin/php" ]; then
+        system_php="/usr/bin/php"
+fi
+
+php_binary="$HESTIA_PHP"
+if [ -z "$php_binary" ] || [ ! -x "$php_binary" ]; then
+        php_binary="$system_php"
+fi
+
+if [ -z "$php_binary" ] || [ ! -x "$php_binary" ]; then
+        echo "ERROR: Unable to locate a PHP binary required for installing Tulio dependencies."
+        exit 1
+fi
+
+openssl_installed=$("$php_binary" -m 2>/dev/null | grep openssl || true)
+
+if [ -z "$system_php" ] || [ ! -x "$system_php" ]; then
+        system_php="$php_binary"
+fi
+
 cd "$PM_INSTALL_DIR"
 rm --recursive --force ${PM_INSTALL_DIR}/vendor
 mkdir -p ${PM_INSTALL_DIR}/vendor
 chown $user: -R ${PM_INSTALL_DIR}/vendor
 
-openssl_installed=$(/usr/local/tulio/php/bin/php -m | grep openssl)
 if [ -z "$openssl_installed" ]; then
-	COMPOSER_HOME="$HOMEDIR/$user/.config/composer" user_exec /usr/bin/php $COMPOSER_BIN --quiet --no-dev install
+        COMPOSER_HOME="$HOMEDIR/$user/.config/composer" user_exec "$system_php" "$COMPOSER_BIN" --quiet --no-dev install
 else
-	COMPOSER_HOME="$HOMEDIR/$user/.config/composer" user_exec $HESTIA_PHP $COMPOSER_BIN --quiet --no-dev install
+        COMPOSER_HOME="$HOMEDIR/$user/.config/composer" user_exec "$php_binary" "$COMPOSER_BIN" --quiet --no-dev install
 fi
 
 # Check if installation was successful, if not abort script and throw error message notification and clean-up
@@ -94,9 +114,9 @@ mkdir -p ${QUICK_INSTALL_DIR}/vendor
 chown $user: -R ${QUICK_INSTALL_DIR}/vendor
 
 if [ -z "$openssl_installed" ]; then
-	COMPOSER_HOME="$HOMEDIR/$user/.config/composer" user_exec /usr/bin/php $COMPOSER_BIN --quiet --no-dev install
+        COMPOSER_HOME="$HOMEDIR/$user/.config/composer" user_exec "$system_php" "$COMPOSER_BIN" --quiet --no-dev install
 else
-	COMPOSER_HOME="$HOMEDIR/$user/.config/composer" user_exec $HESTIA_PHP $COMPOSER_BIN --quiet --no-dev install
+        COMPOSER_HOME="$HOMEDIR/$user/.config/composer" user_exec "$php_binary" "$COMPOSER_BIN" --quiet --no-dev install
 fi
 
 # Set permissions

--- a/bin/v-add-sys-filemanager
+++ b/bin/v-add-sys-filemanager
@@ -65,7 +65,26 @@ check_tulio_demo_mode
 #                       Action                             #
 #----------------------------------------------------------#
 
-openssl_installed=$(/usr/local/tulio/php/bin/php -m | grep openssl)
+system_php=$(command -v php 2>/dev/null || true)
+if [ -z "$system_php" ] && [ -x "/usr/bin/php" ]; then
+        system_php="/usr/bin/php"
+fi
+
+php_binary="$HESTIA_PHP"
+if [ -z "$php_binary" ] || [ ! -x "$php_binary" ]; then
+        php_binary="$system_php"
+fi
+
+if [ -z "$php_binary" ] || [ ! -x "$php_binary" ]; then
+        echo "ERROR: Unable to locate a PHP binary required for the File Manager installation."
+        exit 1
+fi
+
+openssl_installed=$("$php_binary" -m 2>/dev/null | grep openssl || true)
+
+if [ -z "$system_php" ] || [ ! -x "$system_php" ]; then
+        system_php="$php_binary"
+fi
 
 rm --recursive --force "$FM_INSTALL_DIR"
 mkdir -p "$FM_INSTALL_DIR"
@@ -83,9 +102,9 @@ cp --recursive --force ${HESTIA_INSTALL_DIR}/filemanager/filegator/* "${FM_INSTA
 chown $user: -R "${FM_INSTALL_DIR}"
 
 if [ -z "$openssl_installed" ]; then
-	COMPOSER_HOME="$HOMEDIR/$user/.config/composer" user_exec /usr/bin/php $COMPOSER_BIN --quiet --no-dev install
+        COMPOSER_HOME="$HOMEDIR/$user/.config/composer" user_exec "$system_php" "$COMPOSER_BIN" --quiet --no-dev install
 else
-	COMPOSER_HOME="$HOMEDIR/$user/.config/composer" user_exec /usr/local/tulio/php/bin/php $COMPOSER_BIN --quiet --no-dev install
+        COMPOSER_HOME="$HOMEDIR/$user/.config/composer" user_exec "$php_binary" "$COMPOSER_BIN" --quiet --no-dev install
 fi
 
 # Check if installation was successful, if not abort script and throw error message notification and clean-up

--- a/func/main.sh
+++ b/func/main.sh
@@ -45,6 +45,14 @@ TULIO_INSTALL_DIR="$TULIO/install/deb"
 TULIO_COMMON_DIR="$TULIO/install/common"
 TULIO_BACKUP="/root/tst_backups/$(date +%d%m%Y%H%M)"
 TULIO_PHP="$TULIO/php/bin/php"
+if [ ! -x "$TULIO_PHP" ]; then
+        php_cmd=$(command -v php 2>/dev/null || true)
+        if [ -n "$php_cmd" ]; then
+                TULIO_PHP="$php_cmd"
+        elif [ -x "/usr/bin/php" ]; then
+                TULIO_PHP="/usr/bin/php"
+        fi
+fi
 USER_DATA=$TULIO/data/users/$user
 WEBTPL=$TULIO/data/templates/web
 MAILTPL=$TULIO/data/templates/mail


### PR DESCRIPTION
## Summary
- add runtime detection in `main.sh` to fall back to a system PHP binary when Tulio's bundled PHP is not yet installed
- update the system dependency and file manager installers to rely on the detected PHP binary and emit clearer errors when PHP is unavailable

## Testing
- bash -n bin/v-add-sys-dependencies
- bash -n bin/v-add-sys-filemanager
- bash -n func/main.sh

------
https://chatgpt.com/codex/tasks/task_b_68cf3c51241883229ea2009fedb0d065